### PR TITLE
deps, v8: fix build torque on Windows

### DIFF
--- a/deps/v8/gypfiles/v8.gyp
+++ b/deps/v8/gypfiles/v8.gyp
@@ -2522,10 +2522,33 @@
         'GCC_ENABLE_CPP_RTTI': 'YES',        # -frtti
       },
       'defines': ['ANTLR4CPP_STATIC'],
+      'defines!': [
+        '_HAS_EXCEPTIONS=0',
+        'BUILDING_V8_SHARED=1',
+      ],
       'include_dirs': [
         '../third_party/antlr4/runtime/Cpp/runtime/src',
         '../src/torque',
       ],
+      # This is defined trough `configurations` for GYP+ninja compatibility
+      'configurations': {
+        'Debug': {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'RuntimeTypeInfo': 'true',
+              'ExceptionHandling': 1,
+            },
+          }
+        },
+        'Release': {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'RuntimeTypeInfo': 'true',
+              'ExceptionHandling': 1,
+            },
+          }
+        },
+      },
       'sources': [
         '../src/torque/TorqueBaseVisitor.cpp',
         '../src/torque/TorqueBaseVisitor.h',


### PR DESCRIPTION
On Windows the torque binary needs to be compiled and linked
with exception semantics and assume V8 is embedded

Fixes: https://github.com/nodejs/node-v8/issues/57

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [X] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
