### PR TITLE
test: update postmortem metadata test

### DIFF
--- a/test/parallel/test-postmortem-metadata.js
+++ b/test/parallel/test-postmortem-metadata.js
@@ -97,7 +97,7 @@ function getExpectedSymbols() {
     'v8dbg_class_SharedFunctionInfo__flags__int',
     'v8dbg_class_SharedFunctionInfo__end_position__int',
     'v8dbg_class_SharedFunctionInfo__function_identifier__Object',
-    'v8dbg_class_SharedFunctionInfo__internal_formal_parameter_count__int',
+    'v8dbg_class_SharedFunctionInfo__internal_formal_parameter_count__uint16_t',
     'v8dbg_class_SharedFunctionInfo__name_or_scope_info__Object',
     'v8dbg_class_SharedFunctionInfo__script__Object',
     'v8dbg_class_SharedFunctionInfo__start_position_and_type__int',


### PR DESCRIPTION
This commit updates the following postmortem metadata constant:

- v8dbg_class_SharedFunctionInfo__internal_formal_parameter_count__int
  - Renamed: v8dbg_class_SharedFunctionInfo__internal_formal_parameter_count__uint16_t
  - V8 commit: https://github.com/v8/v8/commit/53d4dfc3771dda011ba95d0f825fabb83219ff51

Fixes: #64

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
