### PR TITLE
v8: include right headers in torque output

### DIFF
--- a/deps/v8/src/torque/implementation-visitor.cc
+++ b/deps/v8/src/torque/implementation-visitor.cc
@@ -4001,6 +4001,27 @@ void ImplementationVisitor::GenerateExportedMacrosAssembler(
     h_contents << "#include \"torque-generated/csa-types-tq.h\"\n";
     h_contents
         << "#include \"torque-generated/internal-class-definitions-tq.h\"\n";
+
+    cc_contents << "#include \"src/objects/free-space.h\"\n";
+    cc_contents << "#include \"src/objects/js-regexp-string-iterator.h\"\n";
+    cc_contents << "#include \"src/objects/ordered-hash-table.h\"\n";
+    cc_contents << "#include \"src/objects/property-descriptor-object.h\"\n";
+    cc_contents << "#include \"src/objects/synthetic-module.h\"\n";
+    cc_contents << "#include \"src/objects/template-objects.h\"\n";
+    {
+      IfDefScope intl_scope(cc_contents, "V8_INTL_SUPPORT");
+      cc_contents << "#include \"src/objects/js-break-iterator.h\"\n";
+      cc_contents << "#include \"src/objects/js-collator.h\"\n";
+      cc_contents << "#include \"src/objects/js-date-time-format.h\"\n";
+      cc_contents << "#include \"src/objects/js-display-names.h\"\n";
+      cc_contents << "#include \"src/objects/js-list-format.h\"\n";
+      cc_contents << "#include \"src/objects/js-locale.h\"\n";
+      cc_contents << "#include \"src/objects/js-number-format.h\"\n";
+      cc_contents << "#include \"src/objects/js-plural-rules.h\"\n";
+      cc_contents << "#include \"src/objects/js-relative-time-format.h\"\n";
+      cc_contents << "#include \"src/objects/js-segment-iterator.h\"\n";
+      cc_contents << "#include \"src/objects/js-segmenter.h\"\n";
+    }
     cc_contents << "#include \"torque-generated/" << file_name << ".h\"\n";
 
     for (SourceId file : SourceFileMap::AllSources()) {


### PR DESCRIPTION
Credits goes to @bnoordhuis , he does all the hard work. See https://github.com/nodejs/node-v8/pull/133.

I add one more line (4006). 
```cpp
    cc_contents << "#include \"src/objects/property-descriptor-object.h\"\n";
```

Verified on Visual Studio 2017 Developer Command Prompt v15.9.20.

Fix #128 