### PR TITLE
ci: add minimum GitHub token permissions for workflow

### DIFF
--- a/.github/workflows/update-canary.yml
+++ b/.github/workflows/update-canary.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   updateCanary:
     name: Update the canary branch


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/nodejs/node-v8/actions/runs/3167512719/jobs/5158057075#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflow:

- update-canary.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>