### PR TITLE
chore: update deprecated Node.js 16 actions

### DIFF
--- a/.github/workflows/update-canary.yml
+++ b/.github/workflows/update-canary.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.CANARY_UPDATE }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
 
@@ -26,7 +26,7 @@ jobs:
         run: npm install -g @node-core/utils
 
       - name: Cache V8 clone
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: v8
           key: v8-clone


### PR DESCRIPTION
Update actions/setup-node and actions/cache to v4, which use Node.js 20.