### PR TITLE
build: use Clang 19 to build canary updates

### DIFF
--- a/.github/workflows/update-canary.yml
+++ b/.github/workflows/update-canary.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  CC: clang
-  CXX: clang++
+  CC: clang-19
+  CXX: clang++-19
 
 jobs:
   updateCanary:
@@ -15,6 +15,10 @@ jobs:
     if: github.repository == 'nodejs/node-v8' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     steps:
+      - name: Install Clang 19
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-19
       - name: Clone node-v8
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
On Ubuntu the GitHub runner, the default Clang is 18.
I am still able to build canary locally on my mac with the equivalent of Clang 19.
This should fix this error: https://github.com/nodejs/node-v8/actions/runs/17322059123/job/49177396647