### PR TITLE
tools: clean repo before build

### DIFF
--- a/tools/update-canary.sh
+++ b/tools/update-canary.sh
@@ -20,6 +20,9 @@ git-node v8 major --branch=lkgr --base-dir="$GITHUB_WORKSPACE"
 # Canary-base is the last good version of canary, and is manually updated with any V8 patches or backports.
 git cherry-pick `git log upstream/canary-base -1 --format=format:%H --grep "src: update NODE_MODULE_VERSION"`...upstream/canary-base
 
+# Clean the repository so we're sure the build doesn't accidentally depend on gitignored files
+git clean -fdx
+
 # Verify that Node.js can be compiled and executed
 python3 ./configure
 make -j $(getconf _NPROCESSORS_ONLN) V=


### PR DESCRIPTION
The V8 update script clones V8 and its deps, and patches V8's gitignore file. Clean the repository of all ignored files so the build fails if we forget to update the ignore rules.